### PR TITLE
update PostGIS 2.5.1 and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# PostgreSQL with GEOS 3.6.0 and PostGIS 2.4dev
+# PostgreSQL with GEOS 3.7.1 and PostGIS 2.5.1
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-A custom PostgreSQL Docker image based off GEOS 3.6.0 and PostGIS 2.3.1.
+A custom PostgreSQL Docker image based off GEOS 3.7.1 and PostGIS 2.5.1.
 
 ## Usage
 


### PR DESCRIPTION
I just make PostGIS 2.5.1 version, because I want to check performance of ST_ASMVT for postserve.

- support current postgres:9.6 docker image(jessie -> stretch)
- update all programs version.
- delete un-used ENV and refactor ENV.
- delete some dev packages.

My image is slim than openmaptiles/postgis:2.9 (maybe debian docker image become slim).

```
docker images
REPOSITORY                          TAG                 IMAGE ID            CREATED             SIZE
openmaptiles-dev-postgis            3.0                 c2bd59bb45c1        2 hours ago         860MB
openmaptiles/postgis                2.9                 6358e604686f        19 months ago       1.2GB
```