### PR TITLE
update PostgreSQL 11, PostGIS 2.5.1 and others

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6
+FROM postgres:11
 MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
 ENV POSTGIS_VERSION=2.5.1 \
     GEOS_VERSION=3.7.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,7 +110,7 @@ RUN apt-get -qq -y update \
         unzip \
         xsltproc \
         libpq-dev \
-        postgresql-server-dev-9.6 \
+        postgresql-server-dev-$PG_MAJOR \
         libxml2-dev \
         libjson-c-dev \
         libgdal-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN apt-get -qq -y update \
         libxml2-dev \
         libjson-c-dev \
         libgdal-dev \
+&& rm -rf /usr/local/lib/*.a \
 && rm -rf /var/lib/apt/lists/*
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# PostgreSQL with GEOS 3.6.0 and PostGIS 2.4dev
+# PostgreSQL with GEOS 3.7.1 and PostGIS 2.5.1
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-A custom PostgreSQL Docker image based off GEOS 3.6.0 and PostGIS 2.3.1.
+A custom PostgreSQL Docker image based off GEOS 3.7.1 and PostGIS 2.5.1.
 
 ## Usage
 


### PR DESCRIPTION
I just make new docker image for our community (OpenStreetMap Foundation Japan) testing. Just update PostgreSQL major version from [prev PR](https://github.com/openmaptiles/postgis/pull/10) because 11 performance is better than 9.6.

- support current postgres:11 docker image
  - debian image use stretch
  - upgrade PostgreSQL major version
- update all programs version.
- delete un-used ENV and refactor ENV.
- delete some dev packages.
- delete /usr/local/lib/*.a static libraries