### PR TITLE
Migrate to a well known PostGIS docker base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,94 +1,46 @@
-FROM postgres:11
-MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
-ENV POSTGIS_VERSION=2.5.1 \
-    GEOS_VERSION=3.7.1 \
-    PROTOBUF_VERSION=3.6.1 \
-    PROTOBUF_C_VERSION=1.3.1 \
-    UTF8PROC_TAG=v2.2.0 \
-    MAPNIK_GERMAN_L10N_TAG=v2.5.4
+FROM mdillon/postgis:11
+
+LABEL MAINTAINER "Yuri Astrakhan <YuriAstrakhan@gmail.com>"
+
+ENV UTF8PROC_TAG=v2.2.0 \
+    MAPNIK_GERMAN_L10N_TAG=v2.5.5
 
 RUN apt-get -qq -y update \
- && apt-get -qq -y --no-install-recommends install \
-        autoconf \
-        automake \
-        autotools-dev \
+    ##
+    ## Install build dependencies
+    && apt-get -qq -y --no-install-recommends install \
         build-essential \
         ca-certificates \
-        bison \
-        cmake \
+        # Required by Nominatim to download data files
         curl \
-        dblatex \
-        docbook-mathml \
-        docbook-xsl \
         git \
-        gdal-bin \
-        libcunit1-dev \
-        libkakasi2-dev \
-        libtool \
         pandoc \
-        unzip \
-        xsltproc \
-        # PostGIS build dependencies
-            libgdal-dev \
-            libjson-c-dev \
-            libproj-dev \
-            libxml2-dev \
-            postgresql-server-dev-$PG_MAJOR \
-## GEOS
- && cd /opt/ \
- && curl -o /opt/geos.tar.bz2 http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 \
- && mkdir /opt/geos \
- && tar xf /opt/geos.tar.bz2 -C /opt/geos --strip-components=1 \
- && cd /opt/geos/ \
- && ./configure \
- && make -j \
- && make install \
- && rm -rf /opt/geos* \
-## Protobuf
- && cd /opt/ \
- && curl -L https://github.com/google/protobuf/archive/v$PROTOBUF_VERSION.tar.gz | tar xvz && cd protobuf-$PROTOBUF_VERSION \
- && ./autogen.sh \
- && ./configure \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/protobuf-$PROTOBUF_VERSION \
-## Protobuf-c
- && cd /opt/ \
- && curl -L https://github.com/protobuf-c/protobuf-c/releases/download/v$PROTOBUF_C_VERSION/protobuf-c-$PROTOBUF_C_VERSION.tar.gz | tar xvz && cd protobuf-c-$PROTOBUF_C_VERSION \
- && ./configure \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/protobuf-c-$PROTOBUF_C_VERSION \
-## Postgis
- && cd /opt/ \
- && curl -L https://download.osgeo.org/postgis/source/postgis-$POSTGIS_VERSION.tar.gz | tar xvz && cd postgis-$POSTGIS_VERSION \
- && ./autogen.sh \
- && ./configure CFLAGS="-O0 -Wall" \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/postgis-$POSTGIS_VERSION \
-## UTF8Proc
- && cd /opt/ \
- && git clone https://github.com/JuliaLang/utf8proc.git \
- && cd utf8proc \
- && git checkout -q $UTF8PROC_TAG \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/utf8proc \
-## Mapnik German
- && cd /opt/ \
- && git clone https://github.com/giggls/mapnik-german-l10n.git \
- && cd mapnik-german-l10n \
- && git checkout -q $MAPNIK_GERMAN_L10N_TAG \
- && make \
- && make install \
- && rm -rf /opt/mapnik-german-l10n \
-## Cleanup
- && apt-get -qq -y --auto-remove purge \
+        # $PG_MAJOR is declared in postgres docker
+        postgresql-server-dev-$PG_MAJOR \
+        libkakasi2-dev \
+        libgdal-dev \
+    ##
+    ## UTF8Proc
+    && cd /opt/ \
+    && git clone https://github.com/JuliaLang/utf8proc.git \
+    && cd utf8proc \
+    && git checkout -q $UTF8PROC_TAG \
+    && make \
+    && make install \
+    && ldconfig \
+    && rm -rf /opt/utf8proc \
+    ##
+    ## osml10n extension (originally Mapnik German)
+    && cd /opt/ \
+    && git clone https://github.com/giggls/mapnik-german-l10n.git \
+    && cd mapnik-german-l10n \
+    && git checkout -q $MAPNIK_GERMAN_L10N_TAG \
+    && make \
+    && make install \
+    && rm -rf /opt/mapnik-german-l10n \
+    ##
+    ## Cleanup
+    && apt-get -qq -y --auto-remove purge \
         autoconf \
         automake \
         autotools-dev \
@@ -110,11 +62,12 @@ RUN apt-get -qq -y update \
         unzip \
         xsltproc \
         libpq-dev \
-        postgresql-server-dev-9.6 \
+        postgresql-server-dev-$PG_MAJOR \
         libxml2-dev \
         libjson-c-dev \
         libgdal-dev \
-&& rm -rf /usr/local/lib/*.a \
-&& rm -rf /var/lib/apt/lists/*
+    && rm -rf /usr/local/lib/*.a \
+    && rm -rf /var/lib/apt/lists/*
 
-COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh
+## The script should run after the parent's postgis.sh runs
+COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/postgisZ.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.6
+FROM postgres:11
 MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
 ENV POSTGIS_VERSION=2.5.1 \
     GEOS_VERSION=3.7.1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,6 +114,7 @@ RUN apt-get -qq -y update \
         libxml2-dev \
         libjson-c-dev \
         libgdal-dev \
+&& rm -rf /usr/local/lib/*.a \
 && rm -rf /var/lib/apt/lists/*
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# PostgreSQL with GEOS 3.6.0 and PostGIS 2.4dev
+# PostgreSQL with GEOS 3.7.1 and PostGIS 2.5.1
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-A custom PostgreSQL Docker image based off GEOS 3.6.0 and PostGIS 2.3.1.
+A custom PostgreSQL Docker image based off GEOS 3.7.1 and PostGIS 2.5.1.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# PostgreSQL with GEOS 3.7.1 and PostGIS 2.5.1
+# PostGIS + OSM-specific extensions Docker image
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-A custom PostgreSQL Docker image based off GEOS 3.7.1 and PostGIS 2.5.1.
+This images is based on PostgreSQL 11 and PostGIS 2.5 [Docker image](https://hub.docker.com/r/mdillon/postgis/) and includes [osml10n extension](https://github.com/giggls/mapnik-german-l10n.git) - OSM-specific label manipulation support.
 
 ## Usage
 

--- a/initdb-postgis.sh
+++ b/initdb-postgis.sh
@@ -3,17 +3,10 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-PGUSER="$POSTGRES_USER" psql --dbname="$POSTGRES_DB" <<-'EOSQL'
-    CREATE DATABASE template_postgis;
-    UPDATE pg_database SET datistemplate = TRUE WHERE datname = 'template_postgis';
-EOSQL
-
 for db in template_postgis "$POSTGRES_DB"; do
 PGUSER="$POSTGRES_USER" psql --dbname="$db" <<-'EOSQL'
-    CREATE EXTENSION postgis;
-    CREATE EXTENSION hstore;
-    CREATE EXTENSION unaccent;
-    CREATE EXTENSION fuzzystrmatch;
-    CREATE EXTENSION osml10n;
+    CREATE EXTENSION IF NOT EXISTS hstore;
+    CREATE EXTENSION IF NOT EXISTS unaccent;
+    CREATE EXTENSION IF NOT EXISTS osml10n;
 EOSQL
 done


### PR DESCRIPTION
Continued excellent work by @smellman.
Now the container is based on [mdillon/postgis:11](https://hub.docker.com/r/mdillon/postgis/), and only adds the osml10n extension.

Also a minor version bump to osml10n 2.5.5

**Note**  This PR has already been published on Docker Hub under [sophox/postgis](https://hub.docker.com/r/sophox/postgis) (`:latest` is PG 11, and also `:9.6`) -- feel free to use it directly from there.