### PR TITLE
Use Postgres 12 and PostGIS 3.0.0 from upstream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,10 +30,10 @@ ARG POSTGRES_MAJOR
 ARG POSTGIS_MAJOR
 ARG OSML10N_VER=2.5.7
 
-COPY --from=l10n /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_amd64.deb /tmp
+COPY --from=l10n /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_*.deb /tmp
 
 RUN apt-get update \
-   && apt-get install -y postgresql-${POSTGRES_MAJOR}-postgis-${POSTGIS_MAJOR} /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_amd64.deb \
+   && apt-get install -y postgresql-${POSTGRES_MAJOR}-postgis-${POSTGIS_MAJOR} /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_*.deb \
    && rm -rf /var/lib/apt/lists/*
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ ARG POSTGRES_MAJOR=12
 ARG POSTGIS_MAJOR=3
 ARG OSML10N_VER=2.5.7
 
-FROM postgres:${POSTGRES_MAJOR} AS l10n
+FROM postgres:${POSTGRES_MAJOR} AS builder
 
 ARG POSTGRES_MAJOR
 ARG POSTGIS_MAJOR
@@ -10,8 +10,9 @@ ARG OSML10N_VER
 
 USER root
 
+# Compile mapnik
 RUN apt-get update \
-   && apt-get install -y postgresql-server-dev-${POSTGRES_MAJOR} devscripts equivs
+   && apt-get install -y postgresql-server-dev-${POSTGRES_MAJOR} devscripts equivs git
 
 ADD https://github.com/giggls/mapnik-german-l10n/archive/v${OSML10N_VER}.tar.gz /tmp/mapnik-german-l10n.tar.gz
 
@@ -22,6 +23,20 @@ RUN cd /tmp \
    && DEBIAN_FRONTEND=noninteractive mk-build-deps -ir -t "apt-get -qq --no-install-recommends" debian/control \
    && PG_SUPPORTED_VERSIONS=${POSTGRES_MAJOR} make deb
 
+# Build gdal with PG 12 support (https://github.com/OSGeo/gdal/commit/963618e77de4eee5e7321f5f5ca7abc2b7287fa2)
+WORKDIR /tmp/build
+
+RUN echo "deb-src http://deb.debian.org/debian buster main" >> /etc/apt/sources.list
+
+RUN apt-get update && apt -y build-dep gdal-bin
+RUN git clone --single-branch --branch release/2.4 https://github.com/OSGeo/gdal.git
+RUN cd gdal && git checkout 963618e77de4eee5e7321f5f5ca7abc2b7287fa2
+RUN cd gdal/gdal && ls && ./configure && make && make install DESTDIR=/tmp/gdal
+
+RUN mkdir /tmp/deb && \
+    mv /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_$(dpkg --print-architecture).deb \
+       /tmp/deb
+
 FROM postgres:${POSTGRES_MAJOR}
 
 MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
@@ -30,10 +45,12 @@ ARG POSTGRES_MAJOR
 ARG POSTGIS_MAJOR
 ARG OSML10N_VER=2.5.7
 
-COPY --from=l10n /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_*.deb /tmp
-
+COPY --from=builder /tmp/deb /tmp/deb
+COPY --from=builder /tmp/gdal/ /
 RUN apt-get update \
-   && apt-get install -y postgresql-${POSTGRES_MAJOR}-postgis-${POSTGIS_MAJOR} /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_*.deb \
+   && apt-get install -y postgresql-${POSTGRES_MAJOR}-postgis-${POSTGIS_MAJOR} /tmp/deb/* \
    && rm -rf /var/lib/apt/lists/*
+
+ENV PROJSO libproj.so.13
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,112 +1,39 @@
-FROM postgres:9.6
-MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
-ENV POSTGIS_MAJOR=2.4dev \
-    POSTGIS_VERSION=2.4dev \
-    GEOS_VERSION=3.6.0
+ARG POSTGRES_MAJOR=12
+ARG POSTGIS_MAJOR=3
+ARG OSML10N_VER=2.5.7
 
-RUN apt-get -qq -y update \
- && apt-get -qq -y --no-install-recommends install \
-        autoconf \
-        automake \
-        autotools-dev \
-        build-essential \
-        ca-certificates \
-        bison \
-        cmake \
-        curl \
-        dblatex \
-        docbook-mathml \
-        docbook-xsl \
-        git \
-        gdal-bin \
-        libcunit1-dev \
-        libkakasi2-dev \
-        libtool \
-        pandoc \
-        unzip \
-        xsltproc \
-        # PostGIS build dependencies
-            libgdal-dev \
-            libjson0-dev \
-            libproj-dev \
-            libxml2-dev \
-            postgresql-server-dev-$PG_MAJOR \
-## GEOS
- && cd /opt/ \
- && curl -o /opt/geos.tar.bz2 http://download.osgeo.org/geos/geos-$GEOS_VERSION.tar.bz2 \
- && mkdir /opt/geos \
- && tar xf /opt/geos.tar.bz2 -C /opt/geos --strip-components=1 \
- && cd /opt/geos/ \
- && ./configure \
- && make -j \
- && make install \
- && rm -rf /opt/geos* \
-## Protobuf
- && cd /opt/ \
- && curl -L https://github.com/google/protobuf/archive/v3.0.2.tar.gz | tar xvz && cd protobuf-3.0.2 \
- && ./autogen.sh \
- && ./configure \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/protobuf-3.0.2 \
-## Protobuf-c
- && cd /opt/ \
- && curl -L https://github.com/protobuf-c/protobuf-c/releases/download/v1.2.1/protobuf-c-1.2.1.tar.gz | tar xvz && cd protobuf-c-1.2.1 \
- && ./configure \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/protobuf-c.1.2.1 \
-## Postgis
- && cd /opt/ \
- && git clone -b svn-trunk https://github.com/postgis/postgis.git \  
- && cd postgis \
- && git reset --hard ff0a844e606622f45841fc25221bbaa136ed1001 \ 
- && ./autogen.sh \
- && ./configure CFLAGS="-O0 -Wall" \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/postgis \
-## UTF8Proc
- && cd /opt/ \
- && git clone https://github.com/JuliaLang/utf8proc.git \
- && cd utf8proc \
- && git checkout -q v2.0.2 \
- && make \
- && make install \
- && ldconfig \
- && rm -rf /opt/utf8proc \
-## Mapnik German
- && cd /opt/ \
- && git clone https://github.com/openmaptiles/mapnik-german-l10n.git \
- && cd mapnik-german-l10n \
- && make \
- && make install \
- && rm -rf /opt/mapnik-german-l10n \
-## Cleanup
- && apt-get -qq -y --auto-remove purge \
-        autoconf \
-        automake \
-        autotools-dev \
-        build-essential \
-        ca-certificates \
-        bison \
-        cmake \
-        curl \
-        dblatex \
-        docbook-mathml \
-        docbook-xsl \
-        git \
-        libcunit1-dev \
-        libtool \
-        make \
-        g++ \
-        gcc \
-        pandoc \
-        unzip \
-        xsltproc \
-&& rm -rf /var/lib/apt/lists/*
+FROM postgres:${POSTGRES_MAJOR} AS l10n
+
+ARG POSTGRES_MAJOR
+ARG POSTGIS_MAJOR
+ARG OSML10N_VER
+
+USER root
+
+RUN apt-get update \
+   && apt-get install -y postgresql-server-dev-${POSTGRES_MAJOR} devscripts equivs
+
+ADD https://github.com/giggls/mapnik-german-l10n/archive/v${OSML10N_VER}.tar.gz /tmp/mapnik-german-l10n.tar.gz
+
+RUN cd /tmp \
+   && tar xvf mapnik-german-l10n.tar.gz \
+   && cd mapnik-german-l10n-${OSML10N_VER} \
+   && cat debian/control \
+   && DEBIAN_FRONTEND=noninteractive mk-build-deps -ir -t "apt-get -qq --no-install-recommends" debian/control \
+   && PG_SUPPORTED_VERSIONS=${POSTGRES_MAJOR} make deb
+
+FROM postgres:${POSTGRES_MAJOR}
+
+MAINTAINER "Lukas Martinelli <me@lukasmartinelli.ch>"
+
+ARG POSTGRES_MAJOR
+ARG POSTGIS_MAJOR
+ARG OSML10N_VER=2.5.7
+
+COPY --from=l10n /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_amd64.deb /tmp
+
+RUN apt-get update \
+   && apt-get install -y postgresql-${POSTGRES_MAJOR}-postgis-${POSTGIS_MAJOR} /tmp/postgresql-${POSTGRES_MAJOR}-osml10n_${OSML10N_VER}_amd64.deb \
+   && rm -rf /var/lib/apt/lists/*
 
 COPY ./initdb-postgis.sh /docker-entrypoint-initdb.d/10_postgis.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# PostgreSQL with GEOS 3.6.0 and PostGIS 2.4dev
+# PostgreSQL 12 with PostGIS 3.0.0
 [![](https://images.microbadger.com/badges/image/openmaptiles/postgis.svg)](https://microbadger.com/images/openmaptiles/postgis "Get your own image badge on microbadger.com") [![Docker Automated buil](https://img.shields.io/docker/automated/openmaptiles/postgis.svg)]()
 
-A custom PostgreSQL Docker image based off GEOS 3.6.0 and PostGIS 2.3.1.
+A custom PostgreSQL Docker image based off PostgreSQL 12 and PostGIS 3.0.0
 
 ## Usage
 


### PR DESCRIPTION
I've tested this on the same hardware as https://github.com/openmaptiles/postserve/pull/15
and in the same way (postserve serving tiles and rendering in an openlayers html page) and 
it feels much more responsive.
Here are the timings I'm getting:
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/636/316.pbf (172.19.0.1) 199.06ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/637/316.pbf (172.19.0.1) 213.33ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/635/317.pbf (172.19.0.1) 349.40ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/635/316.pbf (172.19.0.1) 394.14ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/636/317.pbf (172.19.0.1) 467.19ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/637/317.pbf (172.19.0.1) 573.53ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/638/316.pbf (172.19.0.1) 39.95ms
[I 191021 15:10:07 web:2246] 304 GET /tiles/10/638/317.pbf (172.19.0.1) 51.17ms
[I 191021 15:12:02 web:2246] 200 GET /tiles/10/639/317.pbf (172.19.0.1) 68.65ms
[I 191021 15:12:05 web:2246] 200 GET /tiles/10/639/318.pbf (172.19.0.1) 99.92ms
[I 191021 15:12:05 web:2246] 200 GET /tiles/10/638/318.pbf (172.19.0.1) 118.73ms
[I 191021 15:12:05 web:2246] 200 GET /tiles/10/636/318.pbf (172.19.0.1) 149.22ms
[I 191021 15:12:05 web:2246] 200 GET /tiles/10/635/318.pbf (172.19.0.1) 101.32ms
[I 191021 15:12:05 web:2246] 200 GET /tiles/10/637/318.pbf (172.19.0.1) 170.65ms
This is `volga_fed_district` area, and Postgresql is running on an ASUS E520 nettop (Intel(R) Core(TM) i3-7100T CPU @ 3.40GHz, 8 GB Ram) that is running some other stuff as well.

In the postserve PR above I was running Postgres 11 with PostGIS 2.5.3.
I didn't do the tests with the current postgis image.